### PR TITLE
Activate the dbsearch plugin upon starting NodeBB

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -109,6 +109,7 @@ program
     .description('Start the NodeBB server')
     .action(() => {
         require('./running').start(program.opts());
+        require('./manage').activate('nodebb-plugin-dbsearch');
     });
 program
     .command('slog', null, {


### PR DESCRIPTION
**Linked Issues**: Resolves #4, #5.

**Changes**: Modified the `./nodebb start` command to activate the `dbsearch` plugin when ran.

**Testing**: Ran `./nodebb setup`, `./nodebb build`, and `./nodebb start` on a clean install of nodebb. The app running in a browser has a functional search bar.


