### PR TITLE
Gives option to make a new post Anonymous in the UI 

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
@@ -3,7 +3,7 @@
     <span class="visible-sm-inline visible-md-inline visible-lg-inline">{{{ if selectCategoryLabel }}}{selectCategoryLabel}{{{ else }}}[[topic:thread_tools.select_category]]{{{ end }}}</span><span class="visible-xs-inline"><i class="fa fa-fw {{{ if selectCategoryIcon }}}{selectCategoryIcon}{{{ else }}}fa-list{{{ end }}}"></i></span>
     {{{ end }}}</span> <span class="caret"></span>
 </button>
-<button type = "button" class="btn btn-default dropdown-toggle">
+<button type = "button"">
     Post as Anonymous
 </button>
 <div component="category-selector-search" class="hidden">

--- a/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
@@ -3,7 +3,7 @@
     <span class="visible-sm-inline visible-md-inline visible-lg-inline">{{{ if selectCategoryLabel }}}{selectCategoryLabel}{{{ else }}}[[topic:thread_tools.select_category]]{{{ end }}}</span><span class="visible-xs-inline"><i class="fa fa-fw {{{ if selectCategoryIcon }}}{selectCategoryIcon}{{{ else }}}fa-list{{{ end }}}"></i></span>
     {{{ end }}}</span> <span class="caret"></span>
 </button>
-<button type = "button">
+<button type = "button" class="btn btn-default dropdown-toggle">
     Post as Anonymous
 </button>
 <div component="category-selector-search" class="hidden">

--- a/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
@@ -3,7 +3,7 @@
     <span class="visible-sm-inline visible-md-inline visible-lg-inline">{{{ if selectCategoryLabel }}}{selectCategoryLabel}{{{ else }}}[[topic:thread_tools.select_category]]{{{ end }}}</span><span class="visible-xs-inline"><i class="fa fa-fw {{{ if selectCategoryIcon }}}{selectCategoryIcon}{{{ else }}}fa-list{{{ end }}}"></i></span>
     {{{ end }}}</span> <span class="caret"></span>
 </button>
-<button type = "button"">
+<button type = "button">
     Post as Anonymous
 </button>
 <div component="category-selector-search" class="hidden">

--- a/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
@@ -3,6 +3,9 @@
     <span class="visible-sm-inline visible-md-inline visible-lg-inline">{{{ if selectCategoryLabel }}}{selectCategoryLabel}{{{ else }}}[[topic:thread_tools.select_category]]{{{ end }}}</span><span class="visible-xs-inline"><i class="fa fa-fw {{{ if selectCategoryIcon }}}{selectCategoryIcon}{{{ else }}}fa-list{{{ end }}}"></i></span>
     {{{ end }}}</span> <span class="caret"></span>
 </button>
+<button type = "button" class="btn btn-default dropdown-toggle">
+    Post as Anonymous
+</button>
 <div component="category-selector-search" class="hidden">
     <input type="text" class="form-control" autocomplete="off">
 </div>


### PR DESCRIPTION
Resolves #7

Modified `themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl`

Front-end feature only.

Simply adds a new button next to topic selection dropdown button when making a new post. When clicked, the button temporarily gives an alert to let the user know that their post will be anonymous (I would like to enhance the UI for the 'Anonymous Assurance'). 