### PR TITLE
Fix styling on Anonymous Posting Button

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -161,7 +161,7 @@
 	"composer.handle_placeholder": "Enter your name/handle here",
 	"composer.discard": "Discard",
 	"composer.submit": "Submit",
-	"composer.submit_anonymously": "Submit as Anonymous",
+	"composer.submit_anonymously": "Submit Anonymously",
 	"composer.additional-options": "Additional Options",
 	"composer.schedule": "Schedule",
 	"composer.replying_to": "Replying to %1",

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -161,6 +161,7 @@
 	"composer.handle_placeholder": "Enter your name/handle here",
 	"composer.discard": "Discard",
 	"composer.submit": "Submit",
+	"composer.submit_anonymously": "Submit as Anonymous",
 	"composer.additional-options": "Additional Options",
 	"composer.schedule": "Schedule",
 	"composer.replying_to": "Replying to %1",

--- a/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/category-selector-content.tpl
@@ -3,9 +3,6 @@
     <span class="visible-sm-inline visible-md-inline visible-lg-inline">{{{ if selectCategoryLabel }}}{selectCategoryLabel}{{{ else }}}[[topic:thread_tools.select_category]]{{{ end }}}</span><span class="visible-xs-inline"><i class="fa fa-fw {{{ if selectCategoryIcon }}}{selectCategoryIcon}{{{ else }}}fa-list{{{ end }}}"></i></span>
     {{{ end }}}</span> <span class="caret"></span>
 </button>
-<button type = "button" class="btn btn-default composer-anon">
-    Post as Anonymous
-</button>
 <div component="category-selector-search" class="hidden">
     <input type="text" class="form-control" autocomplete="off">
 </div>


### PR DESCRIPTION
fixes #7 

The original Anonymous submission button was not next to the original submit button which may cause users to have confusion regarding the button's function. 

I simply undid the original change that I made to add the original button and added a new button in the same row division as the original submit button but with the CSS format of the discard button in the New Post box to help users discern the regular submit button to the anonymous submit button. 

The next step for this functionality is to add UI features to hide profile pictures of individuals who have posted anonymously.