### PR TITLE
Hide identifying information about a user in their anonymous post

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -1,7 +1,7 @@
 <div class="clearfix post-header">
     <div class="icon pull-left">
         <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
-            <!-- IF !posts.isAnonymous --> <img style="max-height: 50px; max-width: 50px; margin-right: 50px;" src="https://www.pngkey.com/png/full/503-5035055_a-festival-celebrating-tractors-profile-picture-placeholder-round.png" alt="W3Schools.com">
+            <!-- IF posts.isAnonymous --> <img style="max-height: 50px; max-width: 50px; margin-right: 50px;" src="https://www.pngkey.com/png/full/503-5035055_a-festival-celebrating-tractors-profile-picture-placeholder-round.png" alt="W3Schools.com">
             <!-- ELSE --> {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
             <!-- ENDIF posts.isAnonymous -->
             

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -11,7 +11,9 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            <!-- IF posts.isAnonymous --> <i>username hidden</i>
+            <!-- ELSE --> <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            <!-- ENDIF !posts.isAnonymous -->
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -1,7 +1,7 @@
 <div class="clearfix post-header">
     <div class="icon pull-left">
         <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
-            <!-- IF !posts.isAnonymous --> 
+            <!-- IF !posts.isAnonymous --> <img style="max-height: 50px; max-width: 50px; margin-right: 50px;" src="https://www.pngkey.com/png/full/503-5035055_a-festival-celebrating-tractors-profile-picture-placeholder-round.png" alt="W3Schools.com">
             <!-- ELSE --> {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
             <!-- ENDIF posts.isAnonymous -->
             

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -1,7 +1,10 @@
 <div class="clearfix post-header">
     <div class="icon pull-left">
         <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
-            {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
+            <!-- IF !posts.isAnonymous --> 
+            <!-- ELSE --> {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
+            <!-- ENDIF posts.isAnonymous -->
+            
             <i component="user/status" class="fa fa-circle status {posts.user.status}" title="[[global:{posts.user.status}]]"></i>
         </a>
     </div>


### PR DESCRIPTION
**Linked Issues**: Resolves #37

**Changes**: Modified `/themes/nodebb-theme-persona/templates/partials/topic/post.tpl` so that the poster's profile picture and name are hidden if the post is marked as anonymous.

**Testing**: Ran the project in a browser and viewed both an anonymous and non-anonymous post. The anonymous post had a generic profile picture with 'username hidden' in place of the username. The non-anonymous post had the user's profile picture and name shown.