### PR TITLE
StandardJS static analysis tool test

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -12,7 +12,7 @@
     "scripts": {
         "start": "npx tsc && node loader.js",
         "lint": "npx tsc && eslint --cache ./nodebb .",
-        "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
+        "test": "standard && npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
         "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
         "postinstall": "patch-package"
@@ -172,7 +172,8 @@
         "nyc": "15.1.0",
         "smtp-server": "3.11.0",
         "typescript": "^4.9.4",
-        "patch-package": "6.5.1"
+        "patch-package": "6.5.1",
+        "standard": "*"
     },
     "resolutions": {
         "*/jquery": "3.6.3"


### PR DESCRIPTION
Added StandardJS to dev dependencies in package.json as well as in the test script.

**Set up steps:**
`npm install standard --save-dev`
`npx standard <insert filename or directory>`

You may run `npx standard --fix` to immediately solve some issues.

**Sample output:**
<img width="1280" alt="Screenshot 2023-03-17 at 9 41 53 AM" src="https://user-images.githubusercontent.com/84162412/225922754-cdc18946-a77d-43bf-9979-c6c6f55dda6c.png">

